### PR TITLE
Fix Breadcumb Container

### DIFF
--- a/admin/client/src/components/Breadcrumb/Breadcrumb.scss
+++ b/admin/client/src/components/Breadcrumb/Breadcrumb.scss
@@ -8,6 +8,7 @@
 
 .breadcrumb__container {
   max-height: $toolbar-height;
+  flex-basis: 100%;
 }
 
 .breadcrumb>li.breadcrumb__item--last, // TODO Fix Bootstrap clash


### PR DESCRIPTION
Breacrumb container doesn't fill available space and causes text-wrap